### PR TITLE
feat: enhance UI with blue theme and charts

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,185 @@
+// 主交互逻辑
+import {initData, getMetrics, getRecentUpdates, getDeptCounts, getMonthlyTrend, getDirectories} from './data.js';
+import {drawBarChart, drawLineChart, drawPieChart, exportPNG} from './charts.js';
+
+initData();
+
+const pages = document.querySelectorAll('.page');
+const navLinks = document.querySelectorAll('.nav-link');
+
+function showPage(id){
+  pages.forEach(p=>p.classList.add('hidden'));
+  document.getElementById(id).classList.remove('hidden');
+  navLinks.forEach(l=>l.classList.toggle('active', l.dataset.page===id));
+}
+
+window.addEventListener('hashchange',()=>{
+  const page = location.hash.replace('#','') || 'home';
+  showPage(page);
+  if(page==='home') renderHome();
+  if(page==='directory') renderTable();
+  if(page==='stats') renderStats();
+});
+
+// 初始展示
+const startPage = location.hash.replace('#','') || 'home';
+showPage(startPage);
+if(startPage==='home') renderHome();
+if(startPage==='directory') renderTable();
+if(startPage==='stats') renderStats();
+
+// 主题切换
+const themeToggle=document.getElementById('themeToggle');
+let theme = localStorage.getItem('theme') || 'light';
+setTheme(theme);
+
+themeToggle.addEventListener('click',()=>{
+  theme = theme==='dark'?'light':'dark';
+  setTheme(theme);
+});
+
+function setTheme(th){
+  document.documentElement.setAttribute('data-theme',th);
+  localStorage.setItem('theme',th);
+  themeToggle.textContent= th==='dark'? '☀️':'🌙';
+  renderCharts(); // 主题改变时重绘图表
+}
+
+// 首页渲染
+function renderHome(){
+  renderMetrics();
+  renderTimeline();
+  renderDeptBar();
+  renderUpdateLine();
+}
+
+function renderMetrics(){
+  const box = document.getElementById('metrics');
+  box.innerHTML='';
+  const m = getMetrics();
+  const data=[
+    {label:'总目录',value:m.total,icon:'📚',bg:'#1E88E5'},
+    {label:'开放目录',value:m.open,icon:'🔓',bg:'#42A5F5'},
+    {label:'部门数',value:m.departments,icon:'🏢',bg:'#1976D2'},
+    {label:'本月新增',value:m.monthAdd,icon:'📈',bg:'#64B5F6'}
+  ];
+  data.forEach(d=>{
+    const card=document.createElement('div');
+    card.className='metric-card';
+    card.style.background=d.bg;
+    card.innerHTML=`<div><div>${d.label}</div><div style="font-size:1.5rem">${d.value}</div></div><i>${d.icon}</i>`;
+    box.appendChild(card);
+  });
+}
+
+function renderTimeline(){
+  const list = document.getElementById('timeline');
+  list.innerHTML='<h3>近期更新时间</h3>';
+  getRecentUpdates().forEach(item=>{
+    const div=document.createElement('div');
+    div.className='timeline-item';
+    div.innerHTML=`<time>${item.date}</time> <span>${item.name}</span>`;
+    list.appendChild(div);
+  });
+}
+
+function renderDeptBar(){
+  const map = getDeptCounts();
+  const labels = Object.keys(map);
+  const values = Object.values(map);
+  drawBarChart(document.getElementById('deptBar'), labels, values);
+}
+
+function renderUpdateLine(){
+  const trend = getMonthlyTrend();
+  const labels = Array.from({length:12},(_,i)=>`${i+1}月`);
+  drawLineChart(document.getElementById('updateLine'), labels, trend);
+}
+
+function renderCharts(){
+  if(!document.getElementById('deptBar')) return; // 未加载首页
+  renderDeptBar();
+  renderUpdateLine();
+  if(!document.getElementById('statsChart').classList.contains('hidden')){
+    renderStats();
+  }
+}
+
+// 目录管理表格
+function renderTable(){
+  const dirs = getDirectories();
+  const thead=document.querySelector('#dirTable thead');
+  const tbody=document.querySelector('#dirTable tbody');
+  thead.innerHTML='';
+  tbody.innerHTML='';
+  const headers=['名称','部门','共享级别','状态','更新时间'];
+  const tr=document.createElement('tr');
+  headers.forEach(h=>{
+    const th=document.createElement('th');
+    th.textContent=h;
+    const resizer=document.createElement('div');
+    resizer.className='resizer';
+    resizer.addEventListener('mousedown',initResize);
+    th.appendChild(resizer);
+    tr.appendChild(th);
+  });
+  thead.appendChild(tr);
+  dirs.forEach(d=>{
+    const row=document.createElement('tr');
+    row.innerHTML=`<td>${d.name}</td><td>${d.department}</td><td>${d.shareLevel}</td><td>${d.status}</td><td>${d.lastUpdated}</td>`;
+    tbody.appendChild(row);
+  });
+}
+
+// 导出 CSV
+function exportCSV(){
+  const dirs = getDirectories();
+  const headers=['名称','部门','共享级别','状态','更新时间'];
+  const rows = dirs.map(d=>[d.name,d.department,d.shareLevel,d.status,d.lastUpdated]);
+  const csv=[headers.join(','),...rows.map(r=>r.join(','))].join('\n');
+  const link=document.createElement('a');
+  link.href='data:text/csv;charset=utf-8,'+encodeURIComponent(csv);
+  link.download='directories.csv';
+  link.click();
+}
+
+document.getElementById('exportCsv').addEventListener('click',exportCSV);
+
+// 列宽拖动
+let startX,startWidth,thEl;
+function initResize(e){
+  thEl = e.target.parentElement;
+  startX = e.pageX;
+  startWidth = thEl.offsetWidth;
+  document.addEventListener('mousemove',onResize);
+  document.addEventListener('mouseup',stopResize);
+}
+function onResize(e){
+  const diff = e.pageX - startX;
+  thEl.style.width = startWidth + diff + 'px';
+}
+function stopResize(){
+  document.removeEventListener('mousemove',onResize);
+  document.removeEventListener('mouseup',stopResize);
+}
+
+// 统计分析图
+function renderStats(){
+  const type=document.getElementById('chartType').value;
+  const map=getDeptCounts();
+  const labels=Object.keys(map);
+  const values=Object.values(map);
+  const canvas=document.getElementById('statsChart');
+  if(type==='bar') drawBarChart(canvas,labels,values);
+  if(type==='line') drawLineChart(canvas,labels,values);
+  if(type==='pie') drawPieChart(canvas,labels,values);
+}
+
+document.getElementById('chartType').addEventListener('change',renderStats);
+document.getElementById('exportPng').addEventListener('click',()=>exportPNG(document.getElementById('statsChart'),'stats.png'));
+
+// 导航汉堡菜单
+const navToggle=document.getElementById('nav-toggle');
+navToggle.addEventListener('click',()=>{
+  document.querySelector('.nav-list').classList.toggle('show');
+});

--- a/charts.js
+++ b/charts.js
@@ -1,0 +1,69 @@
+// 简易图表绘制工具
+function getColor(){
+  return getComputedStyle(document.documentElement).getPropertyValue('--primary').trim();
+}
+
+export function drawBarChart(canvas, labels, values){
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0,0,canvas.width,canvas.height);
+  const w = canvas.width / values.length;
+  const max = Math.max(...values) || 1;
+  ctx.fillStyle = getColor();
+  values.forEach((v,i)=>{
+    const h = v/max* (canvas.height-20);
+    ctx.fillRect(i*w+10, canvas.height-h-10, w-20, h);
+  });
+  ctx.fillStyle = getComputedStyle(document.body).color;
+  ctx.font='12px sans-serif';
+  labels.forEach((l,i)=>{ctx.fillText(l,i*w+10,canvas.height-2);});
+}
+
+export function drawLineChart(canvas, labels, values){
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0,0,canvas.width,canvas.height);
+  const max = Math.max(...values) || 1;
+  const stepX = (canvas.width-20)/(values.length-1);
+  ctx.strokeStyle = getColor();
+  ctx.beginPath();
+  values.forEach((v,i)=>{
+    const x = 10 + i*stepX;
+    const y = canvas.height-10 - v/max*(canvas.height-20);
+    if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
+  });
+  ctx.stroke();
+  ctx.fillStyle = getComputedStyle(document.body).color;
+  ctx.font='12px sans-serif';
+  labels.forEach((l,i)=>{ctx.fillText(l,10+i*stepX,canvas.height-2);});
+}
+
+export function drawPieChart(canvas, labels, values){
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0,0,canvas.width,canvas.height);
+  const total = values.reduce((a,b)=>a+b,0) || 1;
+  let start=0;
+  values.forEach((v,i)=>{
+    const angle = v/total*2*Math.PI;
+    ctx.beginPath();
+    ctx.moveTo(canvas.width/2,canvas.height/2);
+    ctx.fillStyle = shadeColor(getColor(), i*15);
+    ctx.arc(canvas.width/2,canvas.height/2,Math.min(canvas.width,canvas.height)/2-10,start,start+angle);
+    ctx.closePath();
+    ctx.fill();
+    start+=angle;
+  });
+}
+
+function shadeColor(color, percent){
+  const f=parseInt(color.slice(1),16),t=percent<0?0:255,p=Math.abs(percent)/100,
+  R=f>>16,G=f>>8&0x00FF,B=f&0x0000FF;
+  const newColor = '#'+(0x1000000+ (Math.round((t-R)*p)+R)*0x10000 + (Math.round((t-G)*p)+G)*0x100 + (Math.round((t-B)*p)+B)).toString(16).slice(1);
+  return newColor;
+}
+
+// 导出 PNG
+export function exportPNG(canvas, name){
+  const link = document.createElement('a');
+  link.download = name;
+  link.href = canvas.toDataURL('image/png');
+  link.click();
+}

--- a/data.js
+++ b/data.js
@@ -1,0 +1,60 @@
+// 示例数据与数据 API
+const seedData = [
+  {id:'1',name:'地表水质监测月报',department:'水生态环境处',tags:['水质','监测'],shareLevel:'开放',status:'有效',lastUpdated:'2025-07-15'},
+  {id:'2',name:'空气质量日报',department:'大气环境处',tags:['空气','监测'],shareLevel:'共享',status:'有效',lastUpdated:'2025-07-10'},
+  {id:'3',name:'土壤污染场地名录',department:'土壤生态环境处',tags:['土壤'],shareLevel:'内部',status:'停用',lastUpdated:'2025-06-20'},
+  {id:'4',name:'危险废物产生单位名录',department:'固体废物处',tags:['废物'],shareLevel:'开放',status:'有效',lastUpdated:'2025-07-05'},
+  {id:'5',name:'噪声污染源信息',department:'噪声与辐射处',tags:['噪声'],shareLevel:'共享',status:'有效',lastUpdated:'2025-07-01'},
+  {id:'6',name:'排污许可证清单',department:'行政审批处',tags:['排污'],shareLevel:'开放',status:'有效',lastUpdated:'2025-07-18'},
+  {id:'7',name:'生态红线区划数据',department:'自然生态处',tags:['生态'],shareLevel:'共享',status:'有效',lastUpdated:'2025-05-30'},
+  {id:'8',name:'机动车尾气监测',department:'机动车排污处',tags:['尾气'],shareLevel:'开放',status:'有效',lastUpdated:'2025-07-16'}
+];
+
+// 初始化 localStorage
+export function initData(){
+  if(!localStorage.getItem('directories')){
+    localStorage.setItem('directories', JSON.stringify(seedData));
+  }
+}
+
+// 获取全部目录
+export function getDirectories(){
+  return JSON.parse(localStorage.getItem('directories')) || [];
+}
+
+// 统计数据
+export function getMetrics(){
+  const dirs = getDirectories();
+  const total = dirs.length;
+  const open = dirs.filter(d=>d.shareLevel==='开放').length;
+  const departments = new Set(dirs.map(d=>d.department)).size;
+  const month = new Date().getMonth()+1;
+  const monthAdd = dirs.filter(d=>new Date(d.lastUpdated).getMonth()+1===month).length;
+  return {total,open,departments,monthAdd};
+}
+
+// 最近更新列表
+export function getRecentUpdates(){
+  const dirs = getDirectories().slice().sort((a,b)=>new Date(b.lastUpdated)-new Date(a.lastUpdated));
+  return dirs.slice(0,5).map(d=>({date:d.lastUpdated,name:d.name}));
+}
+
+// 部门目录数量
+export function getDeptCounts(){
+  const map = {};
+  getDirectories().forEach(d=>{map[d.department]=(map[d.department]||0)+1;});
+  return map; // {dept:count}
+}
+
+// 近12个月更新趋势
+export function getMonthlyTrend(){
+  const result = Array(12).fill(0);
+  const now = new Date();
+  const dirs = getDirectories();
+  dirs.forEach(d=>{
+    const date = new Date(d.lastUpdated);
+    const diff = (now.getFullYear()-date.getFullYear())*12 + now.getMonth() - date.getMonth();
+    if(diff>=0 && diff<12){result[11-diff]++;}
+  });
+  return result; // 从12个月前到本月
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>生态环境厅数据资源目录管理系统</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <!-- 顶部导航栏 -->
+  <header class="navbar">
+    <h1 class="logo">数据资源目录</h1>
+    <nav id="nav">
+      <button id="nav-toggle" class="hamburger" aria-label="菜单">☰</button>
+      <ul class="nav-list">
+        <li><a href="#home" data-page="home" class="nav-link">首页</a></li>
+        <li><a href="#directory" data-page="directory" class="nav-link">目录管理</a></li>
+        <li><a href="#stats" data-page="stats" class="nav-link">统计分析</a></li>
+      </ul>
+    </nav>
+    <button id="themeToggle" class="theme-btn" aria-label="切换主题">🌙</button>
+  </header>
+
+  <main id="app">
+    <!-- 首页 -->
+    <section id="home" class="page">
+      <div class="home-grid">
+        <div id="metrics" class="metrics"></div>
+        <div id="timeline" class="timeline card"></div>
+        <div class="charts">
+          <canvas id="deptBar" width="400" height="300" class="card"></canvas>
+          <canvas id="updateLine" width="400" height="300" class="card"></canvas>
+        </div>
+      </div>
+    </section>
+
+    <!-- 目录管理 -->
+    <section id="directory" class="page hidden">
+      <div class="table-actions">
+        <button id="exportCsv" class="btn">导出 CSV</button>
+      </div>
+      <div class="table-container card">
+        <table id="dirTable">
+          <thead></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- 统计分析 -->
+    <section id="stats" class="page hidden">
+      <div class="chart-controls">
+        <select id="chartType">
+          <option value="bar">柱状图</option>
+          <option value="line">折线图</option>
+          <option value="pie">饼图</option>
+        </select>
+        <button id="exportPng" class="btn">导出 PNG</button>
+      </div>
+      <canvas id="statsChart" width="600" height="400" class="card"></canvas>
+    </section>
+  </main>
+
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,117 @@
+/* 主题变量：默认浅色模式 */
+:root {
+  --primary: #1E88E5; /* 主色 */
+  --primary-hover: #42A5F5; /* hover 更亮 */
+  --bg: #f5f5f5;
+  --text: #333;
+  --card-bg: #fff;
+  --card-shadow: rgba(0,0,0,0.1);
+}
+
+/* 深色模式变量覆盖 */
+html[data-theme='dark'] {
+  --bg: #121212;
+  --text: #eee;
+  --card-bg: #1e1e1e;
+  --card-shadow: rgba(0,0,0,0.5);
+}
+
+body {
+  margin: 0;
+  font-family: sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+/* 导航栏样式 */
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background: var(--card-bg);
+  box-shadow: 0 2px 4px var(--card-shadow);
+}
+.logo {font-size:1.2rem;}
+.nav-list {
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.nav-list li {margin-left:1rem;}
+.nav-link {
+  text-decoration: none;
+  color: var(--text);
+  padding:0.5rem 0.8rem;
+  border-radius:4px;
+  transition: background 0.3s;
+}
+.nav-link:hover {background: var(--primary-hover);color:#fff;}
+.nav-link.active {background: rgba(30,136,229,0.15);border-bottom:2px solid var(--primary);}
+
+/* 汉堡菜单在移动端显示 */
+.hamburger {display:none;background:none;border:none;font-size:1.5rem;}
+@media(max-width:600px){
+  .nav-list{display:none;flex-direction:column;background:var(--card-bg);position:absolute;top:3rem;right:1rem;box-shadow:0 2px 8px var(--card-shadow);}
+  .nav-list.show{display:flex;}
+  .hamburger{display:block;}
+}
+
+.theme-btn{background:var(--primary);color:#fff;border:none;padding:0.4rem 0.6rem;border-radius:4px;cursor:pointer;transition:transform 0.3s, box-shadow 0.3s;} 
+.theme-btn:hover{background:var(--primary-hover);transform:scale(1.05);box-shadow:0 4px 8px var(--card-shadow);} 
+
+/* 卡片通用样式 */
+.card {
+  background: var(--card-bg);
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 2px 4px var(--card-shadow);
+  transition: box-shadow 0.3s, transform 0.3s;
+}
+.card:hover {box-shadow:0 4px 8px var(--card-shadow);transform:translateY(-2px);}
+
+/* 页面和动画 */
+.page {animation: fade-in 0.5s ease;}
+.hidden {display:none;}
+@keyframes fade-in {from {opacity:0;} to {opacity:1;}}
+
+/* 首页布局 */
+.home-grid {
+  display:grid;
+  grid-template-columns:1fr 1fr;
+  gap:1rem;
+}
+.metrics {display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:1rem;}
+.metric-card{color:#fff;display:flex;align-items:center;justify-content:space-between;padding:1rem;border-radius:8px;box-shadow:0 2px 4px var(--card-shadow);transition:transform 0.3s;}
+.metric-card:hover{transform:scale(1.05);}
+.metric-card i{font-size:2rem;opacity:0.7;}
+.timeline {padding-left:2rem;position:relative;}
+.timeline:before{content:'';position:absolute;left:1rem;top:0;bottom:0;width:2px;background:var(--primary);}
+.timeline-item{position:relative;margin-bottom:1rem;}
+.timeline-item:before{content:'';position:absolute;left:-1.1rem;top:0.3rem;width:0.6rem;height:0.6rem;background:var(--primary);border-radius:50%;}
+.timeline-item time{font-size:0.8rem;color:var(--primary);}
+
+.charts{display:grid;grid-template-columns:1fr;gap:1rem;}
+@media(min-width:900px){.home-grid{grid-template-columns:1fr 1fr;} .charts{grid-template-columns:1fr;}}
+@media(max-width:899px){.home-grid{grid-template-columns:1fr;} .charts{grid-template-columns:1fr;}}
+
+/* 表格样式 */
+.table-container{overflow:auto;}
+table{width:100%;border-collapse:collapse;}
+thead{background:var(--primary);color:#fff;position:sticky;top:0;}
+th,td{padding:0.5rem;border-bottom:1px solid #ccc;}
+th{position:relative;}
+th .resizer{position:absolute;right:0;top:0;height:100%;width:4px;cursor:col-resize;user-select:none;}
+
+html[data-theme='dark'] table{color:#eee;}
+html[data-theme='dark'] thead{background:#0d47a1;}
+html[data-theme='dark'] th,html[data-theme='dark'] td{border-bottom:1px solid #333;}
+
+/* 按钮通用 */
+.btn{background:var(--primary);color:#fff;border:none;padding:0.4rem 0.8rem;border-radius:4px;cursor:pointer;transition:transform 0.3s, box-shadow 0.3s;background:var(--primary);} 
+.btn:hover{background:var(--primary-hover);transform:scale(1.05);box-shadow:0 4px 8px var(--card-shadow);} 
+
+/* 页面切换淡入淡出动画由 JS 添加类控制 */
+.fade-enter{opacity:0;} .fade-enter-active{opacity:1;transition:opacity 0.3s;} .fade-exit{opacity:1;} .fade-exit-active{opacity:0;transition:opacity 0.3s;}


### PR DESCRIPTION
## Summary
- Build initial front-end prototype with navigation and blue theme
- Add dark/light theme toggle stored in localStorage
- Implement home metrics, timeline, department bar chart and monthly trend line
- Provide directory table with CSV export and resizable columns
- Add statistics chart with view switching and PNG export

## Testing
- `node --check app.js`
- `node --check data.js`
- `node --check charts.js`


------
https://chatgpt.com/codex/tasks/task_e_689573a0957c83228418c8584d4a8347