### PR TITLE
feat: add map view and offline export

### DIFF
--- a/eco-catalog/assets/styles.css
+++ b/eco-catalog/assets/styles.css
@@ -1,0 +1,37 @@
+:root {
+  --brand-blue: #1677ff;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', sans-serif;
+}
+
+.ant-layout-header {
+  color: #fff;
+}
+
+.catalog-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+.catalog-toolbar .filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  flex: 1;
+}
+.catalog-toolbar .filters .ant-input {
+  width: 200px;
+}
+.catalog-toolbar .filters .ant-select {
+  width: 120px;
+}
+@media (max-width: 768px) {
+  .catalog-toolbar .filters .ant-input,
+  .catalog-toolbar .filters .ant-select {
+    width: 100%;
+  }
+}

--- a/eco-catalog/data/datasets.json
+++ b/eco-catalog/data/datasets.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "water001",
+    "name": "地表水质监测月报",
+    "department": "水生态环境处",
+    "category": "水环境",
+    "coverage": "武汉市",
+    "updateFrequency": "每月",
+    "format": "CSV",
+    "lastUpdated": "2025-07-15",
+    "fields": [
+      {"name": "station", "type": "string", "description": "监测站", "level": "公开"},
+      {"name": "ph", "type": "number", "description": "pH"}
+    ],
+    "description": "覆盖主要断面水质监测指标的月度汇总。"
+  },
+  {
+    "id": "air001",
+    "name": "城市空气质量日报",
+    "department": "大气环境处",
+    "category": "大气环境",
+    "coverage": "黄石市,咸宁市",
+    "updateFrequency": "每天",
+    "format": "JSON",
+    "lastUpdated": "2025-07-16",
+    "fields": [
+      {"name": "city", "type": "string", "description": "城市", "level": "内部"},
+      {"name": "aqi", "type": "number", "description": "空气质量指数", "level": "公开"}
+    ],
+    "description": "各城市空气质量日监测数据。"
+  },
+  {
+    "id": "soil001",
+    "name": "土壤重金属监测季报",
+    "department": "土壤生态环境处",
+    "category": "土壤环境",
+    "coverage": "荆州市",
+    "updateFrequency": "每季",
+    "format": "XLSX",
+    "lastUpdated": "2025-06-30",
+    "fields": [
+      {"name": "site", "type": "string", "description": "监测点", "level": "公开"},
+      {"name": "pb", "type": "number", "description": "铅含量", "level": "敏感"}
+    ],
+    "description": "重点区域土壤重金属含量季度数据。"
+  }
+]

--- a/eco-catalog/data/geo/province.geojson
+++ b/eco-catalog/data/geo/province.geojson
@@ -1,0 +1,9 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {"type": "Feature", "properties": {"name": "武汉市"}, "geometry": {"type": "Polygon", "coordinates": [[[114,30],[115,30],[115,31],[114,31],[114,30]]]}},
+    {"type": "Feature", "properties": {"name": "黄石市"}, "geometry": {"type": "Polygon", "coordinates": [[[115,29],[116,29],[116,30],[115,30],[115,29]]]}},
+    {"type": "Feature", "properties": {"name": "咸宁市"}, "geometry": {"type": "Polygon", "coordinates": [[[113,29],[114,29],[114,30],[113,30],[113,29]]]}},
+    {"type": "Feature", "properties": {"name": "荆州市"}, "geometry": {"type": "Polygon", "coordinates": [[[112,30],[113,30],[113,31],[112,31],[112,30]]]} }
+  ]
+}

--- a/eco-catalog/index.html
+++ b/eco-catalog/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>生态环境数据资源目录</title>
+  <link rel="stylesheet" href="./libs/antd.min.css" />
+  <link rel="stylesheet" href="./assets/styles.css" />
+</head>
+<body>
+  <div id="root"></div>
+  <script src="./libs/react.production.min.js"></script>
+  <script src="./libs/react-dom.production.min.js"></script>
+  <script src="./libs/dayjs.min.js"></script>
+  <script src="./libs/antd.min.js"></script>
+  <script src="./libs/icons.min.js"></script>
+  <script src="./libs/echarts.min.js"></script>
+  <script src="./libs/jszip.min.js"></script>
+  <script src="./libs/FileSaver.min.js"></script>
+  <script type="module" src="./js/app.js"></script>
+</body>
+</html>

--- a/eco-catalog/js/app.js
+++ b/eco-catalog/js/app.js
@@ -1,0 +1,100 @@
+import Dashboard from './views/Dashboard.js';
+import Catalog from './views/Catalog.js';
+import Detail from './views/Detail.js';
+import About from './views/About.js';
+import Map from './views/Map.js';
+
+const { Layout, Menu, Alert, Drawer, Button } = antd;
+const { useState, useEffect } = React;
+const { GlobalOutlined, MenuOutlined } = icons;
+
+function validateSchema(data) {
+  if (!Array.isArray(data)) return '数据集应为数组';
+  const required = ['id', 'name', 'department', 'category', 'updateFrequency', 'format', 'lastUpdated', 'fields', 'description'];
+  for (let i = 0; i < data.length; i++) {
+    const item = data[i];
+    for (const key of required) {
+      if (!(key in item)) {
+        return `数据项 ${i} 缺少字段 ${key}`;
+      }
+    }
+  }
+  return null;
+}
+
+function App() {
+  const [datasets, setDatasets] = useState([]);
+  const [error, setError] = useState(null);
+  const [route, setRoute] = useState(window.location.hash || '#/');
+  const [width, setWidth] = useState(window.innerWidth);
+  const [drawer, setDrawer] = useState(false);
+
+  useEffect(() => {
+    fetch('./data/datasets.json')
+      .then(r => r.json())
+      .then(json => {
+        const err = validateSchema(json);
+        if (err) setError(err);
+        else setDatasets(json);
+      })
+      .catch(e => setError(e.message));
+  }, []);
+
+  useEffect(() => {
+    const onHash = () => setRoute(window.location.hash || '#/');
+    const onResize = () => setWidth(window.innerWidth);
+    window.addEventListener('hashchange', onHash);
+    window.addEventListener('resize', onResize);
+    return () => {
+      window.removeEventListener('hashchange', onHash);
+      window.removeEventListener('resize', onResize);
+    };
+  }, []);
+
+  const renderRoute = () => {
+    const path = route.split('?')[0];
+    if (path === '#/catalog') return React.createElement(Catalog, { datasets, route });
+    if (path === '#/map') return React.createElement(Map, { datasets });
+    if (path.startsWith('#/detail')) {
+      const id = new URLSearchParams(route.split('?')[1]).get('id');
+      const ds = datasets.find(d => d.id === id);
+      return React.createElement(Detail, { dataset: ds });
+    }
+    if (path === '#/about') return React.createElement(About);
+    return React.createElement(Dashboard, { datasets });
+  };
+
+  const isMobile = width <= 768;
+  const isDesktop = width >= 1024;
+  const menuItems = [
+    { label: '概览', key: '#/' },
+    { label: '目录', key: '#/catalog' },
+    { label: '覆盖地图', key: '#/map', icon: React.createElement(GlobalOutlined) },
+    { label: '关于', key: '#/about' }
+  ];
+  const menu = React.createElement(Menu, {
+    theme: 'dark',
+    selectedKeys: [route.split('?')[0]],
+    items: menuItems,
+    onClick: ({ key }) => { window.location.hash = key; setDrawer(false); }
+  });
+
+  return (
+    React.createElement(Layout, { style: { minHeight: '100vh' } },
+      !isMobile && React.createElement(Layout.Sider, { className: 'site-layout-sider', collapsed: !isDesktop, collapsedWidth: 80 }, menu),
+      React.createElement(Layout, null,
+        React.createElement(Layout.Header, { style: { background: 'var(--brand-blue)', display: 'flex', alignItems: 'center' } },
+          isMobile && React.createElement(Button, { type: 'text', icon: React.createElement(MenuOutlined), onClick: () => setDrawer(true), style: { color: '#fff', marginRight: 16 } }),
+          '生态环境数据资源目录'
+        ),
+        React.createElement(Layout.Content, { style: { padding: 24 } },
+          error && React.createElement(Alert, { type: 'error', message: error, style: { marginBottom: 16 } }),
+          renderRoute()
+        )
+      ),
+      isMobile && React.createElement(Drawer, { placement: 'left', open: drawer, onClose: () => setDrawer(false), bodyStyle: { padding: 0 } }, menu)
+    )
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));

--- a/eco-catalog/js/views/About.js
+++ b/eco-catalog/js/views/About.js
@@ -1,0 +1,8 @@
+export default function About() {
+  return (
+    React.createElement('div', null,
+      React.createElement('h2', null, '关于'),
+      React.createElement('p', null, '本原型数据来源于生态环境相关公开信息，演示更新机制与离线使用。所有资源均已本地化，可在断网情况下使用。')
+    )
+  );
+}

--- a/eco-catalog/js/views/Catalog.js
+++ b/eco-catalog/js/views/Catalog.js
@@ -1,0 +1,105 @@
+const { useState, useMemo, useEffect } = React;
+const { Input, Table, Select, Space, Button, Dropdown, Menu } = antd;
+const { DownOutlined } = icons;
+
+function exportZip(data) {
+  const zip = new JSZip();
+  zip.file('catalog.json', JSON.stringify(data, null, 2));
+  const header = 'id,name,bureau,category,updateFreq,format,updatedAt\n';
+  const rows = data.map(d => [d.id, d.name, d.department, d.category, d.updateFrequency, d.format, d.lastUpdated].join(','));
+  zip.file('catalog.csv', header + rows.join('\n'));
+  const name = dayjs().format('YYYYMMDD-HHmm');
+  zip.generateAsync({ type: 'blob' }).then(blob => {
+    saveAs(blob, `catalog-${name}.zip`);
+  });
+}
+
+export default function Catalog({ datasets, route }) {
+  const categories = useMemo(() => Array.from(new Set(datasets.map(d => d.category))), [datasets]);
+  const departments = useMemo(() => Array.from(new Set(datasets.map(d => d.department))), [datasets]);
+  const [search, setSearch] = useState('');
+  const [category, setCategory] = useState('');
+  const [department, setDepartment] = useState('');
+  const [mobile, setMobile] = useState(window.innerWidth <= 768);
+
+  useEffect(() => {
+    const onResize = () => setMobile(window.innerWidth <= 768);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  const cityParam = useMemo(() => {
+    const q = route.split('?')[1];
+    return q ? new URLSearchParams(q).get('city') : '';
+  }, [route]);
+
+  const filtered = datasets.filter(d => {
+    return (
+      d.name.includes(search) &&
+      (!category || d.category === category) &&
+      (!department || d.department === department) &&
+      (!cityParam || (d.coverage && d.coverage.includes(cityParam)))
+    );
+  });
+
+  const columns = [
+    { title: '名称', dataIndex: 'name', ellipsis: true },
+    { title: '牵头处室', dataIndex: 'department' },
+    { title: '分类', dataIndex: 'category' },
+    { title: '更新频率', dataIndex: 'updateFrequency' },
+    { title: '格式', dataIndex: 'format' },
+    {
+      title: '最近更新',
+      dataIndex: 'lastUpdated',
+      sorter: (a, b) => a.lastUpdated.localeCompare(b.lastUpdated)
+    }
+  ];
+
+  return (
+    React.createElement('div', null,
+      React.createElement('div', { className: 'catalog-toolbar' },
+        React.createElement(Space, { className: 'filters' },
+          React.createElement(Input, {
+            placeholder: '搜索',
+            value: search,
+            onChange: e => setSearch(e.target.value)
+          }),
+          React.createElement(Select, {
+            allowClear: true,
+            placeholder: '分类',
+            value: category || undefined,
+            onChange: v => setCategory(v),
+            options: categories.map(c => ({ value: c, label: c }))
+          }),
+          React.createElement(Select, {
+            allowClear: true,
+            placeholder: '处室',
+            value: department || undefined,
+            onChange: v => setDepartment(v),
+            options: departments.map(d => ({ value: d, label: d }))
+          })
+        ),
+        mobile
+          ? React.createElement(Dropdown, {
+              overlay: React.createElement(Menu, { onClick: ({ key }) => { if (key === 'zip') exportZip(filtered); } },
+                React.createElement(Menu.Item, { key: 'zip' }, '导出 ZIP')
+              )
+            },
+            React.createElement(Button, null, '操作 ', React.createElement(DownOutlined))
+          )
+          : React.createElement(Button, { onClick: () => exportZip(filtered) }, '导出 ZIP')
+      ),
+      React.createElement(Table, {
+        className: 'catalog-table',
+        dataSource: filtered,
+        columns,
+        rowKey: 'id',
+        size: 'small',
+        pagination: { pageSize: 5 },
+        onRow: record => ({
+          onClick: () => window.location.hash = `#/detail?id=${record.id}`
+        })
+      })
+    )
+  );
+}

--- a/eco-catalog/js/views/Dashboard.js
+++ b/eco-catalog/js/views/Dashboard.js
@@ -1,0 +1,51 @@
+const { Card, List, Empty } = antd;
+const { useEffect, useRef } = React;
+
+export default function Dashboard({ datasets }) {
+  const total = datasets.length;
+  const categories = new Set(datasets.map(d => d.category)).size;
+  const lastUpdated = datasets.reduce((max, d) => (d.lastUpdated > max ? d.lastUpdated : max), '');
+  const recent = [...datasets]
+    .sort((a, b) => b.lastUpdated.localeCompare(a.lastUpdated))
+    .slice(0, 5);
+
+  const lineRef = useRef();
+  const today = dayjs();
+  const days = Array.from({ length: 30 }, (_, i) => today.subtract(29 - i, 'day'));
+  const counts = days.map(d => datasets.filter(ds => d.isSame(dayjs(ds.lastUpdated), 'day')).length);
+  const hasData = counts.some(c => c > 0);
+
+  useEffect(() => {
+    if (!hasData) return;
+    const chart = echarts.init(lineRef.current);
+    chart.setOption({
+      xAxis: { type: 'category', data: days.map(d => d.format('MM-DD')) },
+      yAxis: { type: 'value', name: '更新次数/天' },
+      tooltip: { trigger: 'axis' },
+      series: [{ type: 'line', data: counts }]
+    });
+    return () => chart.dispose();
+  }, [datasets]);
+
+  return (
+    React.createElement('div', { className: 'dashboard' },
+      React.createElement('div', { className: 'stats' },
+        React.createElement(Card, { title: '总量', style: { display: 'inline-block', marginRight: 16 } }, total),
+        React.createElement(Card, { title: '类别数', style: { display: 'inline-block', marginRight: 16 } }, categories),
+        React.createElement(Card, { title: '最近更新', style: { display: 'inline-block' } }, lastUpdated)
+      ),
+      React.createElement(Card, { title: '近30天更新频次', style: { marginTop: 16 } },
+        hasData
+          ? React.createElement('div', { ref: lineRef, style: { width: '100%', height: 300 } })
+          : React.createElement(Empty, { image: Empty.PRESENTED_IMAGE_SIMPLE })
+      ),
+      React.createElement('div', { className: 'recent', style: { marginTop: 16 } },
+        React.createElement(List, {
+          header: '最近更新',
+          dataSource: recent,
+          renderItem: item => React.createElement(List.Item, null, `${item.name} (${item.lastUpdated})`)
+        })
+      )
+    )
+  );
+}

--- a/eco-catalog/js/views/Detail.js
+++ b/eco-catalog/js/views/Detail.js
@@ -1,0 +1,64 @@
+const { Descriptions, Table, Button, Drawer, Tag } = antd;
+const { useState, useRef } = React;
+
+export default function Detail({ dataset }) {
+  const [open, setOpen] = useState(false);
+  if (!dataset) {
+    return React.createElement('div', null, '未找到数据集');
+  }
+  const logged = useRef(false);
+  const columns = [
+    { title: '字段名', dataIndex: 'name' },
+    { title: '类型', dataIndex: 'type' },
+    { title: '说明', dataIndex: 'description', ellipsis: true },
+    {
+      title: '敏感级别',
+      dataIndex: 'level',
+      render: lvl => {
+        const level = lvl || '公开';
+        if (!lvl && !logged.current) {
+          console.info('fields.level 缺失，已默认填充为 公开');
+          logged.current = true;
+        }
+        const color = level === '敏感' ? 'error' : level === '内部' ? 'default' : 'processing';
+        return React.createElement(Tag, { color }, level);
+      }
+    }
+  ];
+  return (
+    React.createElement('div', null,
+      React.createElement(Descriptions, { title: dataset.name, bordered: true, column: 1 },
+        React.createElement(Descriptions.Item, { label: '牵头处室' }, dataset.department),
+        React.createElement(Descriptions.Item, { label: '分类' }, dataset.category),
+        React.createElement(Descriptions.Item, { label: '更新频率' }, dataset.updateFrequency),
+        React.createElement(Descriptions.Item, { label: '格式' }, dataset.format),
+        React.createElement(Descriptions.Item, { label: '最近更新' }, dataset.lastUpdated)
+      ),
+      React.createElement('p', { style: { marginTop: 16 } }, dataset.description),
+      React.createElement(Table, {
+        style: { marginTop: 16 },
+        dataSource: dataset.fields,
+        columns,
+        rowKey: 'name',
+        pagination: false
+      }),
+      React.createElement(Button, {
+        type: 'primary',
+        style: { marginTop: 16 },
+        onClick: () => setOpen(true)
+      }, '下载'),
+      React.createElement(Drawer, {
+        title: '下载',
+        placement: 'right',
+        open,
+        width: 300,
+        onClose: () => setOpen(false)
+      },
+        React.createElement('a', {
+          href: `data:application/json;charset=utf-8,${encodeURIComponent(JSON.stringify(dataset))}`,
+          download: `${dataset.id}.json`
+        }, '下载 JSON')
+      )
+    )
+  );
+}

--- a/eco-catalog/js/views/Map.js
+++ b/eco-catalog/js/views/Map.js
@@ -1,0 +1,56 @@
+const { Card } = antd;
+const { useEffect, useRef } = React;
+
+export default function Map({ datasets }) {
+  const ref = useRef();
+
+  useEffect(() => {
+    let chart;
+    fetch('./data/geo/province.geojson')
+      .then(r => r.json())
+      .then(geo => {
+        echarts.registerMap('province', geo);
+        const data = geo.features.map(f => {
+          const name = f.properties.name;
+          const matched = datasets.filter(d => (d.coverage && d.coverage.includes(name)) || (d.city && d.city.includes(name)));
+          const count = matched.length;
+          const latest = matched.reduce((m, d) => d.lastUpdated > m ? d.lastUpdated : m, '');
+          return { name, value: count, latest };
+        });
+        const max = Math.max(...data.map(d => d.value), 0);
+        const pieces = [
+          { value: 0, color: '#ddd', label: '0' },
+          { min: 1, max: Math.max(1, Math.floor(max / 2)), color: '#8dcff8', label: '1-' + Math.max(1, Math.floor(max / 2)) },
+          { min: Math.max(1, Math.floor(max / 2)) + 1, color: '#1677ff', label: (Math.max(1, Math.floor(max / 2)) + 1) + '-' + max }
+        ];
+        chart = echarts.init(ref.current);
+        chart.setOption({
+          tooltip: {
+            trigger: 'item',
+            formatter: p => `${p.name}<br/>数量: ${p.data.value}<br/>最近: ${p.data.latest || '-'}`
+          },
+          visualMap: {
+            type: 'piecewise',
+            left: 'left',
+            bottom: 0,
+            pieces
+          },
+          series: [{
+            type: 'map',
+            map: 'province',
+            data,
+            roam: false,
+            label: { show: false }
+          }]
+        });
+        chart.on('click', params => {
+          window.location.hash = `#/catalog?city=${encodeURIComponent(params.name)}`;
+        });
+      });
+    return () => { chart && chart.dispose(); };
+  }, [datasets]);
+
+  return React.createElement(Card, { title: '覆盖地图' },
+    React.createElement('div', { ref, style: { width: '100%', height: 360 } })
+  );
+}

--- a/eco-catalog/scripts/vendor.sh
+++ b/eco-catalog/scripts/vendor.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+BASE_DIR="$(dirname "$0")/.."
+LIB_DIR="$BASE_DIR/libs"
+mkdir -p "$LIB_DIR"
+cd "$LIB_DIR"
+
+download() {
+  FILE="$1"
+  URL="$2"
+  if [ -f "$FILE" ]; then
+    echo "Skipped $FILE"
+  else
+    curl -L --retry 3 -o "$FILE" "$URL"
+    echo "Downloaded $FILE"
+  fi
+}
+
+download react.production.min.js https://cdn.jsdelivr.net/npm/react@18.2.0/umd/react.production.min.js
+download react-dom.production.min.js https://cdn.jsdelivr.net/npm/react-dom@18.2.0/umd/react-dom.production.min.js
+download antd.min.js https://cdn.jsdelivr.net/npm/antd@5.13.2/dist/antd.min.js
+download antd.min.css https://cdn.jsdelivr.net/npm/antd@5.13.2/dist/antd.min.css
+download icons.min.js https://cdn.jsdelivr.net/npm/@ant-design/icons@5.2.5/dist/index.umd.js
+download dayjs.min.js https://cdn.jsdelivr.net/npm/dayjs@1.11.10/dayjs.min.js
+download echarts.min.js https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js
+download jszip.min.js https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js
+download FileSaver.min.js https://cdn.jsdelivr.net/npm/file-saver@2.0.5/dist/FileSaver.min.js
+
+echo "Vendor libraries ready in $LIB_DIR"


### PR DESCRIPTION
## Summary
- add coverage map with ECharts and route integration
- render 30-day update trend and enable ZIP export with JSZip/FileSaver
- tag dataset fields by sensitivity level and optimize mobile toolbar

## Testing
- `bash scripts/vendor.sh` *(fails: CONNECT tunnel failed, response 403)*
- `node` (export ZIP with jszip: catalog-test.zip 937 bytes; shows CSV and JSON snippets)
- `node` (fields.level 缺失，已默认填充为 公开)


------
https://chatgpt.com/codex/tasks/task_e_689bfb90d0a08322ac3742c45b6b8bab